### PR TITLE
Feat/#22 이메일 인증 관련 이슈

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -28,6 +28,7 @@ module.exports = {
           '@assets': './src/assets',
           '@components': './src/components',
           '@constants': './src/constants',
+          '@contexts': './src/contexts',
           '@hooks': './src/hooks',
           '@screens': './src/screens',
           '@navigation': './src/navigation',

--- a/metro.config.js
+++ b/metro.config.js
@@ -14,6 +14,7 @@ const config = {
       '@assets': path.resolve(__dirname, 'src/assets'),
       '@components': path.resolve(__dirname, 'src/components'),
       '@constants': path.resolve(__dirname, 'src/constants'),
+      '@contexts': path.resolve(__dirname, 'src/contexts'),
       '@hooks': path.resolve(__dirname, 'src/hooks'),
       '@screens': path.resolve(__dirname, 'src/screens'),
       '@navigation': path.resolve(__dirname, 'src/navigation'),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AppNavigator from '@navigation/AppNavigator';
+import ToastProvider from '@contexts/ToastContext';
 
 export default function App() {
   const queryClient = new QueryClient({
@@ -19,7 +20,9 @@ export default function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AppNavigator />
+      <ToastProvider>
+        <AppNavigator />
+      </ToastProvider>
     </QueryClientProvider>
   );
 }

--- a/src/components/EmailVerification/VerificationCodeStep/index.tsx
+++ b/src/components/EmailVerification/VerificationCodeStep/index.tsx
@@ -5,6 +5,7 @@ import ApiError from '@api/ApiError';
 import PinCodeInput from '@components/_common/molecules/PinCodeInput';
 import LinkedButton from '@components/_common/atoms/LinkedButton';
 import Button from '@components/_common/atoms/Button';
+import Timer from '@components/_common/atoms/Timer';
 
 interface VerificationCodeStepProps {
   email: string;
@@ -47,7 +48,7 @@ export default function VerificationCodeStep({ email, nextStep }: VerificationCo
           {error && <S.ErrorText>{error}</S.ErrorText>}
           <S.InfoWrapper>
             <LinkedButton onPress={handleResend}>인증 코드가 오지 않나요?</LinkedButton>
-            <S.Timer>5:00</S.Timer>
+            <Timer />
           </S.InfoWrapper>
         </S.VerificationContainer>
         <Button onPress={handleSubmit}>다음</Button>

--- a/src/components/EmailVerification/VerificationCodeStep/style.ts
+++ b/src/components/EmailVerification/VerificationCodeStep/style.ts
@@ -35,8 +35,6 @@ const InfoWrapper = styled.View`
   justify-content: space-between;
 `;
 
-const Timer = styled.Text``;
-
 const S = {
   AppContainer,
   Layout,
@@ -44,7 +42,6 @@ const S = {
   VerificationContainer,
   Label,
   InfoWrapper,
-  Timer,
 };
 
 export default S;

--- a/src/components/Modal/ToastModal/index.tsx
+++ b/src/components/Modal/ToastModal/index.tsx
@@ -1,0 +1,16 @@
+import Toast from '@components/_common/atoms/Toast';
+import { useEffect, useState } from 'react';
+
+export function ToastModal({ message }: { message: string }) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return <Toast message={message} visible={visible} />;
+}

--- a/src/components/_common/atoms/Timer/index.tsx
+++ b/src/components/_common/atoms/Timer/index.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import S from './style';
+
+export default function Timer() {
+  const [timeLeft, setTimeLeft] = useState(300);
+
+  const formatTime = (time: number) => {
+    const minutes = Math.floor(time / 60);
+    const seconds = time % 60;
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+  };
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTimeLeft(prev => {
+        if (prev <= 0) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <S.TimerWrapper>
+      <S.Timer>{formatTime(timeLeft)}</S.Timer>
+    </S.TimerWrapper>
+  );
+}

--- a/src/components/_common/atoms/Timer/style.ts
+++ b/src/components/_common/atoms/Timer/style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/native';
+
+const TimerWrapper = styled.View``;
+
+const Timer = styled.Text``;
+
+const S = {
+  TimerWrapper,
+  Timer,
+};
+
+export default S;

--- a/src/components/_common/atoms/Toast/index.tsx
+++ b/src/components/_common/atoms/Toast/index.tsx
@@ -1,0 +1,14 @@
+import S from './style';
+
+interface ToastProps {
+  message: string;
+  visible: boolean;
+}
+
+export default function Toast({ message, visible }: ToastProps) {
+  return (
+    <S.ToastContainer isVisible={visible}>
+      <S.Message>{message}</S.Message>
+    </S.ToastContainer>
+  );
+}

--- a/src/components/_common/atoms/Toast/style.ts
+++ b/src/components/_common/atoms/Toast/style.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/native';
+
+const ToastContainer = styled.View<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
+  width: 100%;
+  height: 46px;
+  background-color: #d9d9d9;
+`;
+
+const Message = styled.Text`
+  font-weight: 700;
+`;
+
+const S = {
+  ToastContainer,
+  Message,
+};
+
+export default S;

--- a/src/components/_common/molecules/PinCodeInput/index.tsx
+++ b/src/components/_common/molecules/PinCodeInput/index.tsx
@@ -13,6 +13,11 @@ export default function PinCodeInput({ pinLength, setAuthCode }: PinCodeInputPro
   const inputRefs = useRef<TextInput[]>([]);
 
   const handleChange = (index: number, value: string) => {
+    if (value.length > 1) {
+      handlePaste(value);
+      return;
+    }
+
     const newPinValues = [...pinValues];
     newPinValues[index] = value;
     setPinValues(newPinValues);
@@ -36,13 +41,22 @@ export default function PinCodeInput({ pinLength, setAuthCode }: PinCodeInputPro
     }
   };
 
+  const handlePaste = (value: string) => {
+    const newPinValues = value.split('').slice(0, pinLength);
+    while (newPinValues.length < pinLength) {
+      newPinValues.push('');
+    }
+    setPinValues(newPinValues);
+    setAuthCode?.(newPinValues.join(''));
+  };
+
   return (
     <S.Wrapper>
       {pinValues.map((value, index) => (
         <S.PinInput
           key={index}
           keyboardType='numeric'
-          maxLength={1}
+          maxLength={pinLength}
           value={value}
           hasValue={!!value}
           isFocus={focusIndex === index}

--- a/src/components/_common/molecules/PinCodeInput/index.tsx
+++ b/src/components/_common/molecules/PinCodeInput/index.tsx
@@ -31,8 +31,8 @@ export default function PinCodeInput({ pinLength, setAuthCode }: PinCodeInputPro
     }
   };
 
-  const handleBackspace = (index: number, value: string) => {
-    if (value === '' && index > 0) {
+  const handleBackspace = (index: number) => {
+    if (index > 0) {
       const newPinValues = [...pinValues];
       newPinValues[index] = '';
       setPinValues(newPinValues);
@@ -65,7 +65,7 @@ export default function PinCodeInput({ pinLength, setAuthCode }: PinCodeInputPro
           onChangeText={text => handleChange(index, text)}
           onKeyPress={({ nativeEvent }) => {
             if (nativeEvent.key === 'Backspace') {
-              handleBackspace(index, value);
+              handleBackspace(index);
             }
           }}
           ref={el => {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,70 @@
+import { ToastModal } from '@components/Modal/ToastModal';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+type ToastContextType = {
+  alert: (message: string) => void;
+  error: (message: string) => void;
+  success: (message: string) => void;
+};
+
+export type ToastType = 'default' | 'success' | 'error';
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+  const [toastList, setToastList] = useState<{ id: number; type: ToastType; message: string }[]>(
+    []
+  );
+  const idRef = useRef(0);
+
+  const removeToast = (id: number) => {
+    setToastList(prev => prev.filter(toast => toast.id !== id));
+  };
+
+  const handleAlert = useCallback(
+    (type: ToastType) => (message: string) => {
+      const id = idRef.current;
+      setToastList(prev => [...prev, { id, type, message }]);
+      idRef.current += 1;
+
+      setTimeout(() => removeToast(id), 4000);
+    },
+    []
+  );
+
+  const providerValue = useMemo(
+    () => ({
+      alert: handleAlert('default'),
+      error: handleAlert('error'),
+      success: handleAlert('success'),
+    }),
+    [handleAlert]
+  );
+
+  return (
+    <ToastContext.Provider value={providerValue}>
+      {toastList.map(({ id, message }) => (
+        <ToastModal message={message} key={id} />
+      ))}
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => {
+  const value = useContext(ToastContext);
+
+  if (!value) {
+    throw new Error('Toast Context가 존재하지 않습니다.');
+  }
+
+  return value;
+};

--- a/src/hooks/useEmail.tsx
+++ b/src/hooks/useEmail.tsx
@@ -1,7 +1,10 @@
 import emailApis from '@api/domain/email';
+import { useToast } from '@contexts/ToastContext';
 import { useMutation } from '@tanstack/react-query';
 
 export default function useEmail() {
+  const { error } = useToast();
+
   const sendCodeMutate = useMutation({
     mutationFn: ({ email }: { email: string }) =>
       emailApis.sendCode({
@@ -9,6 +12,10 @@ export default function useEmail() {
       }),
     onSuccess: () => {
       console.log('인증코드 전송 성공');
+    },
+    onError: err => {
+      console.log(err);
+      error(err.message);
     },
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "@assets/*": ["src/assets/*"],
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
+      "@contexts/*": ["src/contexts/*"],
       "@hooks/*": ["src/hooks/*"],
       "@screens/*": ["src/screens/*"],
       "@navigation/*": ["src/navigation/*"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #22 

<br/>

## 🔎 작업 내용

- 인증 코드 복사/붙여넣기 되도록 수정
- 인증 코드 입력 시 백스페이스하면 value 유무 관계없이 뒤로 가도록 설정
- 인증 코드 유효시간 타이머 기능 추가
- 인증 코드 재전송 시 Toast 모달 추가

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

인증 코드 재전송 시 Toast 모달을 추가했습니다.

백엔드에서 인증 코드 발송 제한(x초 간격 제한) 기능을 구현하고, 관련 에러 메시지를 정의해 주시면, Toast 모달 테스트와 발송 제한 시에만 Toast 모달이 뜨도록 조정할 수 있을 것 같습니다.

또한, Toast 모달의 디자인도 정의되어 있어야 할 것 같습니다.
