### PR TITLE
Feat/#33 게시글 생성 화면 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-native-dotenv": "^3.4.11",
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-gesture-handler": "^2.21.2",
+    "react-native-image-picker": "^7.2.3",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-reanimated": "^3.16.5",

--- a/src/components/ContentInput/index.tsx
+++ b/src/components/ContentInput/index.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import S from './style';
+import { Text } from 'react-native';
+
+interface ValueInfo {
+  str: string;
+  isHashtag: boolean;
+  idxArr: number[];
+}
+
+const getValueInfos = (value: string): ValueInfo[] => {
+  if (value.length === 0) {
+    return [];
+  }
+
+  const words = value.split(' '); // 공백을 기준으로 나누기
+  let index = 0;
+
+  return words.map(word => {
+    const idxArr = [index, index + word.length - 1];
+    index += word.length + 1;
+
+    return {
+      str: word,
+      isHashtag: word.startsWith('#'),
+      idxArr,
+    };
+  });
+};
+
+export default function ContentInput() {
+  const [text, setText] = useState<string>('');
+
+  const valueInfos = getValueInfos(text);
+
+  return (
+    <S.ContentInput
+      placeholder='내용을 입력하세요...'
+      onChangeText={setText}
+      multiline={true}
+      textAlignVertical='top'
+    >
+      {valueInfos.map(({ str, isHashtag, idxArr }, index) => {
+        const [startIdx, endIdx] = idxArr;
+        let content = text.slice(startIdx, endIdx + 1);
+        const isLast = index === valueInfos.length - 1;
+
+        return isHashtag ? (
+          <S.HashtagText key={index}>
+            {content}
+            {!isLast && <Text> </Text>}
+          </S.HashtagText>
+        ) : (
+          <S.NormalText key={index}>
+            {content}
+            {!isLast && <Text> </Text>}
+          </S.NormalText>
+        );
+      })}
+    </S.ContentInput>
+  );
+}

--- a/src/components/ContentInput/index.tsx
+++ b/src/components/ContentInput/index.tsx
@@ -46,10 +46,10 @@ export default function ContentInput() {
         const isLast = index === valueInfos.length - 1;
 
         return isHashtag ? (
-          <S.HashtagText key={index}>
-            {content}
+          <Text key={index}>
+            <S.HashtagText>{content}</S.HashtagText>
             {!isLast && <Text> </Text>}
-          </S.HashtagText>
+          </Text>
         ) : (
           <S.NormalText key={index}>
             {content}

--- a/src/components/ContentInput/style.ts
+++ b/src/components/ContentInput/style.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/native';
+
+const ContentInput = styled.TextInput`
+  width: 100%;
+  min-height: 130px;
+  border: 1px solid #9a9a9a;
+  border-radius: 8px;
+  padding: 11px 16px;
+`;
+
+const NormalText = styled.Text`
+  font-size: 13px;
+  color: #000;
+`;
+
+const HashtagText = styled.Text`
+  font-size: 14px;
+  color: #000;
+  background-color: #caf5da;
+  border-radius: 5px;
+`;
+
+const S = {
+  ContentInput,
+  NormalText,
+  HashtagText,
+};
+
+export default S;

--- a/src/components/ImageUploader/index.tsx
+++ b/src/components/ImageUploader/index.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { FlatList } from 'react-native';
+import * as ImagePicker from 'react-native-image-picker';
+import Icon from 'react-native-vector-icons/Feather';
+import S from './style';
+
+export default function ImageUploader() {
+  const [images, setImages] = useState<string[]>([]);
+
+  const selectImage = () => {
+    ImagePicker.launchImageLibrary({ mediaType: 'photo', quality: 1 }, response => {
+      if (response.assets && response.assets[0]?.uri) {
+        setImages([...images, response.assets[0].uri]);
+      }
+    });
+  };
+
+  const removeImage = (index: number) => {
+    const updatedImages = images.filter((_, i) => i !== index);
+    setImages(updatedImages);
+  };
+
+  return (
+    <S.Container hasImages={images.length > 0}>
+      <FlatList
+        data={[...images, null]}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        renderItem={({ item, index }) =>
+          item ? (
+            <S.ImageWrapper key={index}>
+              <S.UploadImage source={{ uri: item }} />
+              <S.CloseButton onPress={() => removeImage(index)}>
+                <Icon name='x' size={16} color='#000' />
+              </S.CloseButton>
+            </S.ImageWrapper>
+          ) : (
+            <S.AddImageButton onPress={selectImage}>
+              <Icon name='plus' size={32} color='#000' />
+            </S.AddImageButton>
+          )
+        }
+        keyExtractor={(_, index) => index.toString()}
+      />
+    </S.Container>
+  );
+}

--- a/src/components/ImageUploader/index.tsx
+++ b/src/components/ImageUploader/index.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FlatList } from 'react-native';
 import * as ImagePicker from 'react-native-image-picker';
 import Icon from 'react-native-vector-icons/Feather';
 import S from './style';
 
-export default function ImageUploader() {
-  const [images, setImages] = useState<string[]>([]);
+interface ImageUploaderProps {
+  images: string[];
+  setImages: (images: string[]) => void;
+}
 
+export default function ImageUploader({ images, setImages }: ImageUploaderProps) {
   const selectImage = () => {
     ImagePicker.launchImageLibrary({ mediaType: 'photo', quality: 1 }, response => {
       if (response.assets && response.assets[0]?.uri) {
@@ -21,7 +24,7 @@ export default function ImageUploader() {
   };
 
   return (
-    <S.Container hasImages={images.length > 0}>
+    <S.Container>
       <FlatList
         data={[...images, null]}
         horizontal

--- a/src/components/ImageUploader/style.ts
+++ b/src/components/ImageUploader/style.ts
@@ -1,9 +1,6 @@
 import styled from '@emotion/native';
 
-const Container = styled.View<{ hasImages: boolean }>`
-  padding-right: 30px;
-  padding-left: ${({ hasImages }) => (hasImages ? '0px' : '30px')};
-`;
+const Container = styled.View``;
 
 const ImageWrapper = styled.View`
   position: relative;

--- a/src/components/ImageUploader/style.ts
+++ b/src/components/ImageUploader/style.ts
@@ -1,0 +1,43 @@
+import styled from '@emotion/native';
+
+const Container = styled.View<{ hasImages: boolean }>`
+  padding-right: 30px;
+  padding-left: ${({ hasImages }) => (hasImages ? '0px' : '30px')};
+`;
+
+const ImageWrapper = styled.View`
+  position: relative;
+  margin-right: 10px;
+`;
+
+const UploadImage = styled.Image`
+  width: 150px;
+  height: 150px;
+  border-radius: 10px;
+  background-color: #ddd;
+`;
+
+const CloseButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+`;
+
+const AddImageButton = styled.TouchableOpacity`
+  width: 150px;
+  height: 150px;
+  border: 1px #000 dashed;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+`;
+
+const S = {
+  Container,
+  ImageWrapper,
+  UploadImage,
+  CloseButton,
+  AddImageButton,
+};
+
+export default S;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -12,6 +12,7 @@ import FeedScreen from '@screens/FeedScreen';
 import MapScreen from '@screens/MapScreen';
 import DMScreen from '@screens/DMScreen';
 import ProfileScreen from '@screens/ProfileScreen';
+import FeedCreateScreen from '@screens/FeedCreateScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -65,6 +66,13 @@ export default function AppNavigator() {
         />
         <Stack.Screen name='Explore' component={ExploreScreen} />
         <Stack.Screen name='Feed' component={FeedScreen} options={{ headerShown: false }} />
+        <Stack.Screen
+          name='FeedCreate'
+          component={FeedCreateScreen}
+          options={{
+            title: '게시글 생성',
+          }}
+        />
         <Stack.Screen name='Map' component={MapScreen} options={{ headerShown: false }} />
         <Stack.Screen
           name='DM'

--- a/src/navigation/HeaderBar/index.tsx
+++ b/src/navigation/HeaderBar/index.tsx
@@ -1,16 +1,27 @@
 import IconButton from '@components/_common/atoms/IconButton';
 import React from 'react';
 import S from './style';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from 'src/types/NavigationTypes';
 
 interface HeaderBarProps {
   showEditButton?: boolean;
 }
 
+type NavigationProp = StackNavigationProp<RootStackParamList>;
+
 export default function HeaderBar({ showEditButton = false }: HeaderBarProps) {
+  const navigation = useNavigation<NavigationProp>();
+
+  const handleEditButton = () => {
+    navigation.navigate('FeedCreate');
+  };
+
   return (
     <S.HeaderContainer>
       <S.ButtonWrapper>
-        {showEditButton && <IconButton iconName='edit' iconSize={25} />}
+        {showEditButton && <IconButton onPress={handleEditButton} iconName='edit' iconSize={25} />}
       </S.ButtonWrapper>
       <S.ImgLogo></S.ImgLogo>
       <S.ButtonWrapper>

--- a/src/screens/FeedCreateScreen/index.tsx
+++ b/src/screens/FeedCreateScreen/index.tsx
@@ -1,11 +1,16 @@
 import ImageUploader from '@components/ImageUploader';
-import MainLayout from '@screens/MainLayout';
-import { Text } from 'react-native';
+import S from './style';
+import { useState } from 'react';
 
 export default function FeedCreateScreen() {
+  const [images, setImages] = useState<string[]>([]);
+
   return (
-    <MainLayout location='FeedCreate'>
-      <ImageUploader />
-    </MainLayout>
+    <S.Layout>
+      <S.ImageLabel>선택한 이미지</S.ImageLabel>
+      <S.ImageForm hasImages={images.length > 0}>
+        <ImageUploader images={images} setImages={setImages} />
+      </S.ImageForm>
+    </S.Layout>
   );
 }

--- a/src/screens/FeedCreateScreen/index.tsx
+++ b/src/screens/FeedCreateScreen/index.tsx
@@ -1,10 +1,11 @@
+import ImageUploader from '@components/ImageUploader';
 import MainLayout from '@screens/MainLayout';
 import { Text } from 'react-native';
 
 export default function FeedCreateScreen() {
   return (
     <MainLayout location='FeedCreate'>
-      <Text>FeedCreateScreen</Text>
+      <ImageUploader />
     </MainLayout>
   );
 }

--- a/src/screens/FeedCreateScreen/index.tsx
+++ b/src/screens/FeedCreateScreen/index.tsx
@@ -1,6 +1,7 @@
 import ImageUploader from '@components/ImageUploader';
 import S from './style';
 import { useState } from 'react';
+import ContentInput from '@components/ContentInput';
 
 export default function FeedCreateScreen() {
   const [images, setImages] = useState<string[]>([]);
@@ -11,6 +12,10 @@ export default function FeedCreateScreen() {
       <S.ImageForm hasImages={images.length > 0}>
         <ImageUploader images={images} setImages={setImages} />
       </S.ImageForm>
+      <S.ContentWrapper>
+        <S.ContentLabel>본문</S.ContentLabel>
+        <ContentInput />
+      </S.ContentWrapper>
     </S.Layout>
   );
 }

--- a/src/screens/FeedCreateScreen/index.tsx
+++ b/src/screens/FeedCreateScreen/index.tsx
@@ -2,20 +2,28 @@ import ImageUploader from '@components/ImageUploader';
 import S from './style';
 import { useState } from 'react';
 import ContentInput from '@components/ContentInput';
+import Button from '@components/_common/atoms/Button';
 
 export default function FeedCreateScreen() {
   const [images, setImages] = useState<string[]>([]);
 
+  const handlePress = () => {};
+
   return (
     <S.Layout>
-      <S.ImageLabel>선택한 이미지</S.ImageLabel>
-      <S.ImageForm hasImages={images.length > 0}>
-        <ImageUploader images={images} setImages={setImages} />
-      </S.ImageForm>
-      <S.ContentWrapper>
-        <S.ContentLabel>본문</S.ContentLabel>
-        <ContentInput />
-      </S.ContentWrapper>
+      <S.FeedCreateContainer>
+        <S.ImageLabel>선택한 이미지</S.ImageLabel>
+        <S.ImageForm hasImages={images.length > 0}>
+          <ImageUploader images={images} setImages={setImages} />
+        </S.ImageForm>
+        <S.ContentWrapper>
+          <S.ContentLabel>본문</S.ContentLabel>
+          <ContentInput />
+        </S.ContentWrapper>
+      </S.FeedCreateContainer>
+      <S.ButtonWrapper>
+        <Button onPress={handlePress}>완료</Button>
+      </S.ButtonWrapper>
     </S.Layout>
   );
 }

--- a/src/screens/FeedCreateScreen/index.tsx
+++ b/src/screens/FeedCreateScreen/index.tsx
@@ -1,0 +1,10 @@
+import MainLayout from '@screens/MainLayout';
+import { Text } from 'react-native';
+
+export default function FeedCreateScreen() {
+  return (
+    <MainLayout location='FeedCreate'>
+      <Text>FeedCreateScreen</Text>
+    </MainLayout>
+  );
+}

--- a/src/screens/FeedCreateScreen/style.ts
+++ b/src/screens/FeedCreateScreen/style.ts
@@ -18,10 +18,22 @@ const ImageLabel = styled.Text`
   font-size: 13px;
 `;
 
+const ContentWrapper = styled.View`
+  padding: 0 30px;
+  margin-top: 15px;
+  max-height: 265px;
+`;
+
+const ContentLabel = styled.Text`
+  margin-bottom: 5px;
+`;
+
 const S = {
   Layout,
   ImageForm,
   ImageLabel,
+  ContentWrapper,
+  ContentLabel,
 };
 
 export default S;

--- a/src/screens/FeedCreateScreen/style.ts
+++ b/src/screens/FeedCreateScreen/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/native';
+
+const Layout = styled.View`
+  padding: 40px 0px;
+  background-color: #fff;
+  width: 100%;
+  height: 100%;
+`;
+
+const ImageForm = styled.View<{ hasImages: boolean }>`
+  padding-right: 30px;
+  padding-left: ${({ hasImages }) => (hasImages ? '0px' : '30px')};
+  margin: 5px 0;
+`;
+
+const ImageLabel = styled.Text`
+  margin-left: 30px;
+  font-size: 13px;
+`;
+
+const S = {
+  Layout,
+  ImageForm,
+  ImageLabel,
+};
+
+export default S;

--- a/src/screens/FeedCreateScreen/style.ts
+++ b/src/screens/FeedCreateScreen/style.ts
@@ -1,11 +1,15 @@
 import styled from '@emotion/native';
 
 const Layout = styled.View`
+  display: flex;
+  justify-content: space-between;
   padding: 40px 0px;
   background-color: #fff;
   width: 100%;
   height: 100%;
 `;
+
+const FeedCreateContainer = styled.View``;
 
 const ImageForm = styled.View<{ hasImages: boolean }>`
   padding-right: 30px;
@@ -28,12 +32,18 @@ const ContentLabel = styled.Text`
   margin-bottom: 5px;
 `;
 
+const ButtonWrapper = styled.View`
+  padding: 0 30px;
+`;
+
 const S = {
+  FeedCreateContainer,
   Layout,
   ImageForm,
   ImageLabel,
   ContentWrapper,
   ContentLabel,
+  ButtonWrapper,
 };
 
 export default S;

--- a/src/types/NavigationTypes.ts
+++ b/src/types/NavigationTypes.ts
@@ -5,6 +5,7 @@ export type RootStackParamList = {
   ResetPassword: undefined;
   Explore: undefined;
   Feed: undefined;
+  FeedCreate: undefined;
   Map: undefined;
   DM: undefined;
   Profile: undefined;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #33

<br/>

## 🔎 작업 내용

- ImageUploader 컴포넌트 추가
- ContentInput 컴포넌트 추가 -> #으로 시작할 시 하이라이트 적용
- 게시글 생성 화면 구현

<br/>

## 이미지 첨부(선택)
<img width="30%" alt="스크린샷 2025-01-22 오후 11 19 56" src="https://github.com/user-attachments/assets/d3fa36e5-43da-4e31-a939-5606438073ec" />

<br/>

## 💬 리뷰 요구사항(선택)

해시태그에 border-radius를 적용하려 했으나, Text 컴포넌트에서는 해당 스타일을 직접 지원하지 않아 적용이 불가능했습니다. Text에 border-radius를 적용하려면 View로 감싸야하지만 TextInput 내부에서는 View를 사용할 수 없기 때문에 결국 radius는 적용하지 못했습니다.
